### PR TITLE
Add domain extension to get escrow account address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Features
 * IBC denom API #97
   * `/ibc/all`
+* Add get escrow account address method for ibc #119
 
 ### Improvements
 * Removed hash conversion #66

--- a/service/src/test/kotlin/io/provenance/explorer/domain/ExtensionsTest.kt
+++ b/service/src/test/kotlin/io/provenance/explorer/domain/ExtensionsTest.kt
@@ -1,6 +1,16 @@
-//package io.provenance.explorer.domain
-//
-//class ExtensionsTest {
-//
-//
-//}
+package io.provenance.explorer.domain
+
+import io.provenance.explorer.grpc.extensions.getEscrowAccountAddress
+import org.junit.jupiter.api.Assertions.assertEquals
+import org.junit.jupiter.api.Tag
+import org.junit.jupiter.api.Test
+
+class ExtensionsTest {
+
+    @Test
+    @Tag("junit-jupiter")
+    fun `should return escrow account address with given portId channelId and prefix`() {
+        val result = getEscrowAccountAddress("transfer", "channel", "cosmos")
+        assertEquals("cosmos1dm7fargcm8km25nxe6xldj0y0j2dawg8h5s03l", result)
+    }
+}


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Created a method to get escrow account address for ibc transfers.  

This should be replaced with an grpc call once cosmos implements: [Issue: 9437](https://github.com/cosmos/cosmos-sdk/issues/9437)

closes: #119

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
