### PR TITLE
Tx msg printed as base64

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -150,3 +150,9 @@ Desktop.ini
 
 database/bin
 /.history/
+
+######################
+# IntelliJ Datasources
+######################
+.ideaDataSources
+dataSources

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Bug Fixes
+* Tx Msgs MetadataAddress types displayed as Base64 strings in UI #145
+
 ### Features
 * Added `msgType={msgType}` to `/api/v2/txs/{hash}/msgs` to allow for filtering based on `msgType` #146
 * Added `/api/v2/txs/types/tx/{hash}` to fetch msg types applicable to a single tx #146

--- a/service/src/main/kotlin/io/provenance/explorer/Application.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/Application.kt
@@ -2,6 +2,7 @@ package io.provenance.explorer
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.databind.PropertyNamingStrategy
+import com.fasterxml.jackson.databind.node.JsonNodeFactory
 import io.provenance.explorer.config.ExplorerProperties
 import io.provenance.explorer.domain.extensions.configureProvenance
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration
@@ -30,4 +31,7 @@ fun main(args: Array<String>) {
 val OBJECT_MAPPER = ObjectMapper()
     .setPropertyNamingStrategy(PropertyNamingStrategy.SNAKE_CASE)
     .configureProvenance()
+
+/* Singleton instance that can safely be shared globally */
+val JSON_NODE_FACTORY: JsonNodeFactory = JsonNodeFactory.instance
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

Fix bug with MetadataAddress being printed as a Base64 string on the UI

The following files were modified:

- .gitignore
- CHANGELOG.md
- service/src/main/kotlin/io/provenance/explorer/Application.kt
- service/src/main/kotlin/io/provenance/explorer/domain/extensions/Extenstions.kt

closes: #145

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
