### PR TITLE
add gas fee statistics per message type

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,21 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Features
+* Added gas fee statistics (min, max, avg, std) per message type on single message transactions [#185](https://github.com/provenance-io/explorer-service/issues/185)
+
+### Improvements
+
+### Bug Fixes
+
+### Data
+* Added caching and aggregate tables for txs with single massages only [#185](https://github.com/provenance-io/explorer-service/issues/185)
+  * Added `tx_single_message_cache` table
+  * Added `tx_single_message_gas_stats_day` table
+  * Added `tx_single_message_gas_stats_hour` table
+  * Added `update_gas_stats` stored procedure
+
+
 ## [v2.2.0](https://github.com/provenance-io/explorer-service/releases/tag/v2.2.0) - 2021-07-29
 ### Release Name: Hyecho
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,9 +45,9 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * Added `tx_single_message_cache` table
   * Added `tx_single_message_gas_stats_day` table
   * Added `tx_single_message_gas_stats_hour` table
-  * Added `update_gas_stats` stored procedure
-
-
+  * Added `update_daily_gas_stats` stored procedure
+  * Added `update_hourly_gas_stats` stored procedure
+  
 ## [v2.2.0](https://github.com/provenance-io/explorer-service/releases/tag/v2.2.0) - 2021-07-29
 ### Release Name: Hyecho
 

--- a/database/src/main/resources/db/migration/V1_24__Add_gas_fee_stats.sql
+++ b/database/src/main/resources/db/migration/V1_24__Add_gas_fee_stats.sql
@@ -1,0 +1,137 @@
+-- Host future and previous migrated data
+CREATE TABLE IF NOT EXISTS tx_single_message_cache
+(
+    id              SERIAL PRIMARY KEY,
+    tx_timestamp    TIMESTAMP          NOT NULL,
+    tx_hash         VARCHAR(64) UNIQUE NOT NULL,
+    gas_used        INT                NOT NULL,
+    tx_message_type VARCHAR(128)       NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS tx_single_message_cache_tx_timestamp_idx
+    ON tx_single_message_cache (tx_timestamp);
+
+CREATE INDEX IF NOT EXISTS tx_single_message_cache_gas_used_idx
+    ON tx_single_message_cache (gas_used);
+
+CREATE INDEX IF NOT EXISTS tx_single_message_cache_tx_message_type_idx
+    ON tx_single_message_cache (tx_message_type);
+
+-- Aggregated HOURLY data for GAS statistics.
+CREATE TABLE IF NOT EXISTS tx_single_message_gas_stats_day
+(
+    tx_timestamp    TIMESTAMP    NOT NULL,
+    min_gas_used    INT          NOT NULL,
+    max_gas_used    INT          NOT NULL,
+    avg_gas_used    INT          NOT NULL,
+    stddev_gas_used INT          NOT NULL,
+    tx_message_type VARCHAR(128) NOT NULL,
+    PRIMARY KEY (tx_timestamp, tx_message_type)
+);
+
+CREATE TABLE IF NOT EXISTS tx_single_message_gas_stats_hour
+(
+    tx_timestamp    TIMESTAMP    NOT NULL,
+    min_gas_used    INT          NOT NULL,
+    max_gas_used    INT          NOT NULL,
+    avg_gas_used    INT          NOT NULL,
+    stddev_gas_used INT          NOT NULL,
+    tx_message_type VARCHAR(128) NOT NULL,
+    PRIMARY KEY (tx_timestamp, tx_message_type)
+);
+
+-- Migrate historical data to tx_single_message_cache
+WITH single_message_txs AS (
+    SELECT tm.tx_hash,
+           -- avoids adding to GROUP BY
+           string_agg(tc.tx_timestamp::TEXT, ',') AS tx_timestamp,
+           string_agg(tc.gas_used::TEXT, ',')     AS gas_used,
+           string_agg(tmt.type::TEXT, ',')        AS tx_message_type
+    FROM tx_message tm
+             INNER JOIN tx_cache tc
+                        ON tc.id = tm.tx_hash_id
+             INNER JOIN tx_message_type tmt
+                        ON tm.tx_message_type_id = tmt.id
+    GROUP BY tm.tx_hash
+    HAVING count(tm.tx_hash) = 1
+),
+     stats AS (
+         SELECT cast(tx_timestamp AS TIMESTAMP) AS tx_timestamp,
+                tx_hash,
+                cast(gas_used AS INT)           AS gas_used,
+                tx_message_type
+         FROM single_message_txs
+     )
+INSERT
+INTO tx_single_message_cache (tx_timestamp, tx_hash, gas_used, tx_message_type)
+SELECT *
+FROM STATS
+ON CONFLICT DO NOTHING;
+
+-- Daily aggregate of historical data
+-- DANGER: If you run this more than once it will generate duplicate data
+INSERT
+INTO tx_single_message_gas_stats_day
+SELECT date_trunc('DAY', tx_timestamp)           AS tx_timestamp,
+       min(gas_used)                             AS min_gas_used,
+       max(gas_used)                             AS max_gas_used,
+       round(avg(gas_used))                      AS avg_gas_used,
+       coalesce(round(stddev_samp(gas_used)), 0) AS stddev_gas_used,
+       tx_message_type
+FROM tx_single_message_cache
+GROUP BY date_trunc('DAY', tx_timestamp),
+         tx_message_type
+ON CONFLICT DO NOTHING;
+
+-- Hourly aggregate of historical data
+-- DANGER: If you run this more than once it will generate duplicate data
+INSERT
+INTO tx_single_message_gas_stats_hour
+SELECT date_trunc('HOUR', tx_timestamp)          AS tx_timestamp,
+       min(gas_used)                             AS min_gas_used,
+       max(gas_used)                             AS max_gas_used,
+       round(avg(gas_used))                      AS avg_gas_used,
+       coalesce(round(stddev_samp(gas_used)), 0) AS stddev_gas_used,
+       tx_message_type
+FROM tx_single_message_cache
+GROUP BY date_trunc('HOUR', tx_timestamp),
+         tx_message_type
+ON CONFLICT DO NOTHING;
+
+-- Update gas stats with latest data
+CREATE OR REPLACE PROCEDURE update_gas_stats(TIMESTAMP, VARCHAR[])
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    var varchar;
+BEGIN
+    -- Delete old records and update with new aggregate counts
+    FOREACH var IN ARRAY $2
+        LOOP
+            EXECUTE
+                format('DELETE
+                        FROM %I
+                        WHERE tx_timestamp >= date_trunc(%L, %L::TIMESTAMP)'::TEXT
+                    , 'tx_single_message_gas_stats_' || var, var, $1);
+
+            EXECUTE
+                format('INSERT
+                        INTO %I
+                        SELECT date_trunc(%L, tx_timestamp)              AS tx_timestamp,
+                               min(gas_used)                             AS min_gas_used,
+                               max(gas_used)                             AS max_gas_used,
+                               round(avg(gas_used))                      AS avg_gas_used,
+                               coalesce(round(stddev_samp(gas_used)), 0) AS stddev_gas_used,
+                               tx_message_type
+                        FROM tx_single_message_cache
+                        WHERE date_trunc(%L, tx_timestamp) >= date_trunc(%L, %L::TIMESTAMP)
+                        GROUP BY date_trunc(%L, tx_timestamp),
+                                 tx_message_type
+                        ON CONFLICT DO NOTHING'::TEXT
+                    , 'tx_single_message_gas_stats_' || var, var, var, var, $1, var);
+        END LOOP;
+
+    RAISE INFO 'UPDATED gas stats for %', $2;
+END;
+$$;

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
@@ -601,6 +601,7 @@ object TxSingleMessageCacheTable : IntIdTable(name = "tx_single_message_cache") 
     val txHash = varchar("tx_hash", 64)
     val gasUsed = integer("gas_used")
     val txMessageType = varchar("tx_message_type", 128)
+    val processed = bool("processed")
 }
 
 class TxSingleMessageCacheRecord(id: EntityID<Int>) : IntEntity(id) {
@@ -612,6 +613,7 @@ class TxSingleMessageCacheRecord(id: EntityID<Int>) : IntEntity(id) {
                 it[this.txHash] = txHash
                 it[this.gasUsed] = gasUsed
                 it[this.txMessageType] = type
+                it[this.processed] = false
             }
         }
 
@@ -667,4 +669,5 @@ class TxSingleMessageCacheRecord(id: EntityID<Int>) : IntEntity(id) {
     var txHash by TxSingleMessageCacheTable.txHash
     var gasUsed by TxSingleMessageCacheTable.gasUsed
     var txMessageType by TxSingleMessageCacheTable.txMessageType
+    var processed by TxSingleMessageCacheTable.processed
 }

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
@@ -653,10 +653,12 @@ class TxSingleMessageCacheRecord(id: EntityID<Int>) : IntEntity(id) {
                 }
         }
 
-        fun updateGasStats(txTimestamp: DateTime): Unit = transaction {
-            val txTimestampUtc = txTimestamp.withZone(DateTimeZone.UTC).toString("yyyy-MM-dd HH:mm:ss")
+        fun updateGasStats(): Unit = transaction {
             val conn = TransactionManager.current().connection
-            val queries = listOf("CALL update_gas_stats('$txTimestampUtc'::TIMESTAMP, '{day,hour}')")
+            val queries = listOf(
+                "CALL update_daily_gas_stats()",
+                "CALL update_hourly_gas_stats()"
+            )
             conn.executeInBatch(queries)
         }
     }

--- a/service/src/main/kotlin/io/provenance/explorer/domain/models/explorer/ExplorerModels.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/models/explorer/ExplorerModels.kt
@@ -28,3 +28,12 @@ data class GasStatistics(
     val maxGasPrice: Int,
     val averageGasPrice: BigDecimal
 )
+
+data class GasStats(
+    val date: String,
+    val minGasPrice: Int,
+    val maxGasPrice: Int,
+    val avgGasPrice: Int,
+    val stdDevGasPrice: Int,
+    val messageType: String
+)

--- a/service/src/main/kotlin/io/provenance/explorer/service/ExplorerService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/ExplorerService.kt
@@ -6,6 +6,7 @@ import io.provenance.explorer.domain.core.logger
 import io.provenance.explorer.domain.entities.BlockCacheRecord
 import io.provenance.explorer.domain.entities.ChainGasFeeCacheRecord
 import io.provenance.explorer.domain.entities.TxCacheRecord
+import io.provenance.explorer.domain.entities.TxSingleMessageCacheRecord
 import io.provenance.explorer.domain.extensions.NHASH
 import io.provenance.explorer.domain.extensions.formattedString
 import io.provenance.explorer.domain.extensions.height
@@ -147,8 +148,19 @@ class ExplorerService(
         Pair<BigDecimal, String>(totalBondedTokens, totalBlockChainTokens)
     }
 
+    @Deprecated(
+        "Use getGasStats(DateTime, DateTime, DateTruncGranularity?)",
+        ReplaceWith(
+            "TxCacheRecord.getGasStats(fromDate, toDate, (granularity ?: DateTruncGranularity.DAY).name)",
+            "io.provenance.explorer.domain.entities.TxCacheRecord",
+            "io.provenance.explorer.domain.models.explorer.DateTruncGranularity"
+        )
+    )
     fun getGasStatistics(fromDate: DateTime, toDate: DateTime, granularity: DateTruncGranularity?) =
         TxCacheRecord.getGasStats(fromDate, toDate, (granularity ?: DateTruncGranularity.DAY).name)
+
+    fun getGasStats(fromDate: DateTime, toDate: DateTime, granularity: DateTruncGranularity?) =
+        TxSingleMessageCacheRecord.getGasStats(fromDate, toDate, (granularity ?: DateTruncGranularity.DAY).name)
 
     fun getGasFeeStatistics(fromDate: DateTime?, toDate: DateTime?, count: Int) =
         ChainGasFeeCacheRecord.findForDates(fromDate, toDate, count).reversed()

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncCaching.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncCaching.kt
@@ -223,7 +223,6 @@ class AsyncCaching(
                         tx.txResponse.gasUsed.toInt(),
                         type
                     )
-                    TxSingleMessageCacheRecord.updateGasStats(tx.txResponse.timestamp.toDateTime())
                 }
             } else
                 TxMessageRecord.insert(tx.txResponse.height.toInt(), tx.txResponse.txhash, txId, msg, UNKNOWN, UNKNOWN)

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncCaching.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncCaching.kt
@@ -26,6 +26,7 @@ import io.provenance.explorer.domain.entities.TxMarkerJoinRecord
 import io.provenance.explorer.domain.entities.TxMessageRecord
 import io.provenance.explorer.domain.entities.TxMessageTypeRecord
 import io.provenance.explorer.domain.entities.TxNftJoinRecord
+import io.provenance.explorer.domain.entities.TxSingleMessageCacheRecord
 import io.provenance.explorer.domain.entities.UNKNOWN
 import io.provenance.explorer.domain.entities.updateHitCount
 import io.provenance.explorer.domain.extensions.height
@@ -214,6 +215,16 @@ class AsyncCaching(
                 }
                 val msgId = TxMessageRecord.insert(tx.txResponse.height.toInt(), tx.txResponse.txhash, txId, msg, type, module).value
                 saveEvents(txId, tx, msgId, type, idx)
+
+                if (tx.tx.body.messagesCount == 1) {
+                    TxSingleMessageCacheRecord.insert(
+                        tx.txResponse.timestamp.toDateTime(),
+                        tx.txResponse.txhash,
+                        tx.txResponse.gasUsed.toInt(),
+                        type
+                    )
+                    TxSingleMessageCacheRecord.updateGasStats(tx.txResponse.timestamp.toDateTime())
+                }
             } else
                 TxMessageRecord.insert(tx.txResponse.height.toInt(), tx.txResponse.txhash, txId, msg, UNKNOWN, UNKNOWN)
         }

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncService.kt
@@ -110,7 +110,7 @@ class AsyncService(
         GovProposalRecord.getNonFinalProposals().forEach { govService.updateProposal(it) }
     }
 
-    @Scheduled(cron = "0/15 * * * * ?") // Every 15 minutes
+    @Scheduled(cron = "0 0 0/1 * * ?") // At the start of every hour
     fun updateGasStats() = transaction {
         logger.info("Updating Gas stats")
         TxSingleMessageCacheRecord.updateGasStats()

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/AsyncService.kt
@@ -6,6 +6,7 @@ import io.provenance.explorer.domain.entities.BlockCacheRecord
 import io.provenance.explorer.domain.entities.BlockProposerRecord
 import io.provenance.explorer.domain.entities.ChainGasFeeCacheRecord
 import io.provenance.explorer.domain.entities.GovProposalRecord
+import io.provenance.explorer.domain.entities.TxSingleMessageCacheRecord
 import io.provenance.explorer.domain.entities.ValidatorGasFeeCacheRecord
 import io.provenance.explorer.domain.extensions.height
 import io.provenance.explorer.domain.extensions.startOfDay
@@ -107,5 +108,11 @@ class AsyncService(
     @Scheduled(cron = "0 0 0 * * ?") // Everyday at 12 am
     fun updateProposalStatus() = transaction {
         GovProposalRecord.getNonFinalProposals().forEach { govService.updateProposal(it) }
+    }
+
+    @Scheduled(cron = "0/15 * * * * ?") // Every 15 minutes
+    fun updateGasStats() = transaction {
+        logger.info("Updating Gas stats")
+        TxSingleMessageCacheRecord.updateGasStats()
     }
 }

--- a/service/src/main/kotlin/io/provenance/explorer/web/v2/GeneralController.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/web/v2/GeneralController.kt
@@ -31,13 +31,21 @@ class GeneralController(private val explorerService: ExplorerService) {
     @GetMapping("/spotlight")
     fun spotlight(): ResponseEntity<Spotlight> = ResponseEntity.ok(explorerService.getSpotlightStatistics())
 
-    @ApiOperation("Returns gas statistics")
-    @GetMapping("/gas/statistics")
+    @Deprecated("This endpoint is not being utilized. Instead, use '/gas/stats'")
+    @ApiOperation("Returns gas statistics", hidden = true)
     fun gasStatistics(
         @RequestParam(required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) fromDate: DateTime,
         @RequestParam(required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) toDate: DateTime,
         @RequestParam(required = false) granularity: DateTruncGranularity?
     ) = ResponseEntity.ok(explorerService.getGasStatistics(fromDate, toDate, granularity))
+
+    @ApiOperation("Returns gas statistics")
+    @GetMapping("/gas/stats")
+    fun gasStats(
+        @RequestParam(required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) fromDate: DateTime,
+        @RequestParam(required = true) @DateTimeFormat(iso = DateTimeFormat.ISO.DATE) toDate: DateTime,
+        @RequestParam(required = false) granularity: DateTruncGranularity?
+    ) = ResponseEntity.ok(explorerService.getGasStats(fromDate, toDate, granularity))
 
     @ApiOperation("Returns the ID of the chain associated with the explorer instance")
     @GetMapping("/chain/id")


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

- Created gas fee statistics tables for day/hour for transactions with single messages.

Design approach:

- Collect single message txs into a cache table `tx_single_message_cache`
- From `tx_single_message_cache`, aggregate `daily` and `hourly` data into `daily` and `hourly` tables.
- Create a `stored procedure` that will update aggregate data based on the `tx_timestamp` of the latest single message transaction. 

closes: #185 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
