### PR TITLE
Bug Fixes: Adding additional check to refresh validator state view

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,16 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Improvements
+* Added checks to refresh the `current_validator_state` view
+  * Should reduce the number of unnecessary refreshes 
+* Updated Spotlight Cache create to use the second top-most height actually in the database
+  * This will prevent a race condition for saving blocks
+
+### Bug Fixes
+* Added `tx_message.msg_idx` to actually have message uniqueness
+* Fixed the hashing function for tx_message to be deterministic
+
 ## [v2.3.0](https://github.com/provenance-io/explorer-service/releases/tag/v2.3.0) - 2021-08-31
 ### Release Name: Erik the Red
 

--- a/database/src/main/resources/db/migration/V1_31__Modify_tx_message.sql
+++ b/database/src/main/resources/db/migration/V1_31__Modify_tx_message.sql
@@ -1,0 +1,7 @@
+
+SELECT 'Updating tx_message' as comment;
+ALTER TABLE tx_message
+    ADD COLUMN IF NOT EXISTS msg_idx INT DEFAULT 0;
+
+
+

--- a/service/src/main/kotlin/io/provenance/explorer/domain/extensions/Extenstions.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/extensions/Extenstions.kt
@@ -48,7 +48,8 @@ fun ByteString.toBase64() = Base64.getEncoder().encodeToString(this.toByteArray(
 fun String.fromBase64() = Base64.getDecoder().decode(this).decodeToString()
 fun String.fromBase64ToMAddress() = Base64.getDecoder().decode(this).toByteString().toMAddress()
 fun String.toBase64() = Base64.getEncoder().encodeToString(this.toByteArray())
-fun ByteString.toDbHash() = Hashing.sha512().hashBytes(this.toByteArray()).asBytes().toString()
+fun ByteArray.base64EncodeString(): String = String(Base64.getEncoder().encode(this))
+fun ByteString.toDbHash() = Hashing.sha512().hashBytes(this.toByteArray()).asBytes().base64EncodeString()
 fun ByteString.toHash() = this.toByteArray().toBech32Data().hexData
 
 // PubKeySecp256k1

--- a/service/src/main/kotlin/io/provenance/explorer/service/BlockService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/BlockService.kt
@@ -14,6 +14,8 @@ import org.springframework.stereotype.Service
 class BlockService(private val blockClient: BlockGrpcClient) {
     protected val logger = logger(BlockService::class)
 
+    fun getMaxBlockCacheHeight() = BlockCacheRecord.getMaxBlockHeight()
+
     fun getBlockIndexFromCache() = BlockIndexRecord.getIndex()
 
     fun getLatestBlockHeightIndex(): Int = getBlockIndexFromCache()!!.maxHeightRead!!

--- a/service/src/main/kotlin/io/provenance/explorer/service/ExplorerService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/ExplorerService.kt
@@ -90,7 +90,7 @@ class ExplorerService(
     }
 
     fun getRecentBlocks(count: Int, page: Int) = let {
-        val currentHeight = blockService.getLatestBlockHeightIndex()
+        val currentHeight = blockService.getLatestBlockHeightIndex() - 1
         var blockHeight = if (page < 0) currentHeight else currentHeight - (count * page)
         val result = mutableListOf<BlockSummary>()
         while (result.size < count) {
@@ -139,7 +139,7 @@ class ExplorerService(
 
     fun createSpotlight() = getBondedTokenRatio().let {
         Spotlight(
-            latestBlock = getBlockAtHeight(null),
+            latestBlock = getBlockAtHeight(blockService.getMaxBlockCacheHeight() - 1),
             avgBlockTime = BlockProposerRecord.findAvgBlockCreation(100),
             bondedTokens = CountStrTotal(it.first.toString(), it.second, NHASH),
             totalTxCount = BlockCacheHourlyTxCountsRecord.getTotalTxCount().toBigInteger()

--- a/service/src/main/kotlin/io/provenance/explorer/service/MigrationService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/MigrationService.kt
@@ -1,15 +1,24 @@
 package io.provenance.explorer.service
 
+import cosmos.tx.v1beta1.ServiceOuterClass
 import io.provenance.explorer.domain.core.logger
 import io.provenance.explorer.domain.entities.AccountRecord
 import io.provenance.explorer.domain.entities.AccountRecord.Companion.update
 import io.provenance.explorer.domain.entities.BlockCacheRecord
 import io.provenance.explorer.domain.entities.BlockCacheTable
 import io.provenance.explorer.domain.entities.BlockProposerRecord
+import io.provenance.explorer.domain.entities.TxCacheTable
+import io.provenance.explorer.domain.entities.TxMessageRecord
+import io.provenance.explorer.domain.entities.TxMessageTable
+import io.provenance.explorer.domain.extensions.execAndMap
+import io.provenance.explorer.domain.extensions.mapper
 import io.provenance.explorer.service.async.AsyncCaching
+import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.sql.SortOrder
+import org.jetbrains.exposed.sql.deleteWhere
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.springframework.stereotype.Service
+import java.sql.ResultSet
 
 @Service
 class MigrationService(
@@ -71,4 +80,119 @@ class MigrationService(
         }
         logger.info("End height: $endHeight")
     }
+
+    fun updateTxMessageMsgIdx(startId: Int, endId: Int, inc: Int) {
+        logger.info("Start id: $startId")
+        transaction {
+            val list = transaction {
+                val query = """select q.*, tc.tx_v2 json from (
+                        select tm.tx_hash_id, count(tm.id) msgCount, min(tm.msg_idx) minIdx, max(tm.msg_idx) maxIdx
+                        from tx_message tm
+                        where tm.tx_hash_id between $startId and $endId
+                        group by tm.tx_hash_id
+                    ) q
+                    join tx_cache tc on q.tx_hash_id = tc.id
+                    where msgCount > 1 and minIdx = maxIdx
+                    order by tx_hash_id
+                    limit $inc
+                """.trimIndent()
+                query.execAndMap { it.toTxMessageMsgIdxResult() }
+            }
+
+            logger.info("deleting tx messages")
+            transaction { TxMessageTable.deleteWhere { TxMessageTable.txHashId inList list.map { it.txHashId } } }
+            list.forEach { obj ->
+                logger.info("saving tx messages")
+                asyncCaching.saveMessages(EntityID(obj.txHashId, TxCacheTable), obj.json)
+            }
+        }
+        logger.info("End id: $endId")
+    }
+
+    fun updateTxMessageCount(min: Int, max: Int, limit: Int) {
+        logger.info("Finding tx hashes")
+        val list = transaction {
+            val query = """select id, hash, height, json, txCount, tmCount from (
+                    select tc.id,
+                         tc.hash,
+                         tc.height,
+                         tc.tx_v2 json,
+                         jsonb_array_length((tc.tx_v2 -> 'tx' -> 'body' ->> 'messages')::jsonb) txCount,
+                         count(tm.id)                                                           tmCount
+                    from tx_cache tc
+                           join tx_message tm on tm.tx_hash_id = tc.id
+                            where tc.id between $min and $max
+                    group by tc.id
+                              ) q
+                    where txCount != tmCount
+                    limit $limit
+            """.trimIndent()
+            query.execAndMap { it.toTxMessageCountResult() }
+        }
+        val recLimit = 200
+        logger.info("mapping tx hashes")
+        list.forEach { obj ->
+            var offset = 0
+            val keepList: MutableList<String> = mutableListOf()
+            val deleteList: MutableList<Int> = mutableListOf()
+            if (obj.txCount > obj.tmCount) {
+                val recList =
+                    transaction { TxMessageRecord.findByHashIdPaginated(obj.txHashId, listOf(), recLimit, offset) }
+                deleteList.addAll(recList.map { it.id.value })
+                transaction { TxMessageTable.deleteWhere { TxMessageTable.id inList deleteList } }
+                logger.info("saving tx messages")
+                asyncCaching.saveMessages(EntityID(obj.txHashId, TxCacheTable), obj.json)
+            } else {
+                var recList =
+                    transaction { TxMessageRecord.findByHashIdPaginated(obj.txHashId, listOf(), recLimit, offset) }
+                do {
+                    recList.forEach { rec ->
+                        if (keepList.contains(rec.txMessageHash))
+                            deleteList.add(rec.id.value)
+                        else keepList.add(rec.txMessageHash)
+                    }
+                    offset += recLimit
+                    recList =
+                        transaction { TxMessageRecord.findByHashIdPaginated(obj.txHashId, listOf(), recLimit, offset) }
+                } while (recList.size > 0)
+
+                logger.info("deleting tx messages")
+                if (keepList.size == obj.txCount)
+                    transaction { TxMessageTable.deleteWhere { TxMessageTable.id inList deleteList } }
+                else logger.warn("Not enough msgs found for txHashId ${obj.txHashId}")
+            }
+        }
+    }
 }
+
+data class TxMessageMsgIdxResult(
+    val txHashId: Int,
+    val msgCount: Int,
+    val minIdx: Int,
+    val maxIdx: Int,
+    val json: ServiceOuterClass.GetTxResponse
+)
+
+fun ResultSet.toTxMessageMsgIdxResult() =
+    TxMessageMsgIdxResult(
+        this.getInt("tx_hash_id"),
+        this.getInt("msgCount"),
+        this.getInt("minIdx"),
+        this.getInt("maxIdx"),
+        this.getString("json").mapper(ServiceOuterClass.GetTxResponse::class.java),
+    )
+
+data class TxMessageCountResult(
+    val txHashId: Int,
+    val txCount: Int,
+    val tmCount: Int,
+    val json: ServiceOuterClass.GetTxResponse
+)
+
+fun ResultSet.toTxMessageCountResult() =
+    TxMessageCountResult(
+        this.getInt("id"),
+        this.getInt("txCount"),
+        this.getInt("tmCount"),
+        this.getString("json").mapper(ServiceOuterClass.GetTxResponse::class.java),
+    )

--- a/service/src/main/kotlin/io/provenance/explorer/service/TransactionService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/TransactionService.kt
@@ -126,7 +126,7 @@ class TransactionService(
 
     // Triple checks that the tx messages are up to date in the db
     fun checkMsgCount(curr: TxCacheRecord): TxCacheRecord =
-        if (transaction { curr.txMessages.count() != curr.txV2.tx.body.messagesCount.toLong() }) {
+        if (transaction { curr.txMessages.count() < curr.txV2.tx.body.messagesCount.toLong() }) {
             asyncCache.addTxToCache(curr.txV2, curr.txTimestamp)
             TxCacheRecord.findByEntityId(curr.id)!!
         } else curr

--- a/service/src/main/kotlin/io/provenance/explorer/web/v2/MigrationController.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/web/v2/MigrationController.kt
@@ -47,4 +47,14 @@ class MigrationController(private val migrationService: MigrationService) {
     @GetMapping("/update/blocks/missed")
     fun updateMissedBlocks(@RequestParam start: Int, @RequestParam end: Int, @RequestParam inc: Int) =
         ResponseEntity.ok(migrationService.updateMissedBlocks(start, end, inc))
+
+    @ApiOperation("Updates tx message msg id")
+    @GetMapping("/update/messages/msgid")
+    fun updateTxMessageId(@RequestParam start: Int, @RequestParam end: Int, @RequestParam inc: Int) =
+        ResponseEntity.ok(migrationService.updateTxMessageMsgIdx(start, end, inc))
+
+    @ApiOperation("Updates tx message count per tx")
+    @GetMapping("/update/messages")
+    fun updateTxMessages(@RequestParam limit: Int, @RequestParam min: Int, @RequestParam max: Int) =
+        ResponseEntity.ok(migrationService.updateTxMessageCount(min, max, limit))
 }


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

* Unnecessary refreshes can bog down the db connections, forcing a service restart
* This should reduce the number of refreshes to the view, and locking of queries against the view
* Made TxMessageSingle cache entry insertIgnore
* Added migration API to fix tx_message.tx_message_hash
* Added migration 1.31 to add msg idx to tx_message table
  * Allows for proper msg uniqueness due to same db hash value.

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
