### PR TITLE
Adding dedicated API to get attribute names by address

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,8 @@ Ref: https://keepachangelog.com/en/1.0.0/
   * GET `/api/v3/grants/authz/{address}/granter` - Returns a paginated list of authz grants granted by the address
   * GET `/api/v3/grants/feegrant/{address}/grantee` - Returns a paginated list of feegrant allowances granted to the address
   * GET `/api/v3/grants/feegrant/{address}/granter` - Returns a 501 until the supporting gRPC query is applied to the chain
+* Added dedicated API for getting Attribute Names by address #346
+  * GET `/api/v2/names/{address}/owned` - Returns attribute names owned by the address; applies to contracts as well
 
 ### Improvements
 * Removed calls to Figment #385

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
@@ -94,9 +94,6 @@ class BlockCacheRecord(id: EntityID<Int>) : CacheEntity<Int>(id) {
                 .first()[dateTrunc].toInt()
         }
 
-        fun test() = transaction {
-        }
-
         fun getMaxBlockHeightOrNull() = transaction {
             val maxHeight = Max(BlockCacheTable.height, IntegerColumnType())
             BlockCacheTable.slice(maxHeight).selectAll().firstOrNull()?.let { it[maxHeight] }

--- a/service/src/main/kotlin/io/provenance/explorer/domain/models/explorer/NameModels.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/models/explorer/NameModels.kt
@@ -13,7 +13,8 @@ data class NameObj(
     val nameList: List<String>,
     val owner: String,
     val restricted: Boolean,
-    val fullName: String
+    val fullName: String,
+    val childCount: Int
 )
 
 data class NameMap(

--- a/service/src/main/kotlin/io/provenance/explorer/service/AccountService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/AccountService.kt
@@ -112,6 +112,7 @@ class AccountService(
         }
     }
 
+    @Deprecated("Use NameService.getNamesOwnedByAddress")
     fun getNamesOwnedByAccount(address: String, page: Int, limit: Int) = runBlocking {
         attrClient.getNamesForAddress(address, page.toOffset(limit), limit).let { res ->
             val names = res.nameList.toList()

--- a/service/src/main/kotlin/io/provenance/explorer/web/v2/AccountControllerV2.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/web/v2/AccountControllerV2.kt
@@ -87,6 +87,8 @@ class AccountControllerV2(private val accountService: AccountService, private va
 
     @ApiOperation("Returns attribute names owned by the account address")
     @GetMapping("/{address}/attributes/owned")
+    @Deprecated("Use /api/v2/names/{address}/owned")
+    @java.lang.Deprecated
     fun getAccountNamesOwned(
         @ApiParam(value = "The address of the account, starting with the standard account prefix")
         @PathVariable address: String,

--- a/service/src/main/kotlin/io/provenance/explorer/web/v2/NameController.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/web/v2/NameController.kt
@@ -3,12 +3,17 @@ package io.provenance.explorer.web.v2
 import io.provenance.explorer.service.NameService
 import io.swagger.annotations.Api
 import io.swagger.annotations.ApiOperation
+import io.swagger.annotations.ApiParam
 import org.springframework.http.MediaType
 import org.springframework.http.ResponseEntity
 import org.springframework.validation.annotation.Validated
 import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import javax.validation.constraints.Max
+import javax.validation.constraints.Min
 
 @Validated
 @RestController
@@ -24,4 +29,14 @@ class NameController(private val nameService: NameService) {
     @ApiOperation("Returns tree of names")
     @GetMapping("/tree")
     fun getNameTree() = ResponseEntity.ok(nameService.getNameMap())
+
+    @ApiOperation("Returns attribute names owned by the address")
+    @GetMapping("/{address}/owned")
+    fun getNamesOwnedByAddress(
+        @ApiParam(value = "The address, starting with the standard account prefix")
+        @PathVariable address: String,
+        @ApiParam(value = "Record count between 1 and 50", defaultValue = "10", required = false)
+        @RequestParam(defaultValue = "10") @Min(1) @Max(50) count: Int,
+        @ApiParam(defaultValue = "1", required = false) @RequestParam(defaultValue = "1") @Min(1) page: Int
+    ) = ResponseEntity.ok(nameService.getNamesOwnedByAddress(address, page, count))
 }


### PR DESCRIPTION


<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

* Deprecated the accounts API to get names, and replaced with generic API to get owned names by address
* Applies to any standard address, including contracts
* Returns restriction and child count

closes: #346

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
