### PR TITLE
Remove adding a Release Name to releases

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -134,7 +134,6 @@ To create a new release:
 - Create the release version branch `release/vx.x.x` (aka `release`)
 - On the `release` branch, prepare a new version section in the `CHANGELOG.md`
   - At the top of latest changes add `## [vx.x.x](https://github.com/provenance-io/explorer-service/releases/tag/vx.x.x) - YYYY-MM-DD`
-  - Beneath that add `### Release Name: xxxxxx` and choose a unique name from [this list](https://en.wikipedia.org/wiki/List_of_explorers)
   - All links must be link-ified: `python3 ./scripts/linkify.py CHANGELOG.md`
   - Copy the latest release entries into a `RELEASE_CHANGELOG.md`, this is needed so the bot knows which entries to add to the release page on github.
   - Commit changes to the `release` branch


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR gets rid of the Explorer name convention we've been using for release names. While it was a fun idea, it didn't really add any value and could even become a problem if we accidentally picked an explorer with a problematic past.

A few reasons for this change:
1. **Not Useful**: The Explorer names didn't end up being all that helpful in practice.
2. **Potential Risk**: There's a chance we could end up associating a release with an explorer who has some baggage, which we definitely want to avoid.
3. **Simplifying the Process**: With more continuous releases planned, this would just add unnecessary work without any real benefit.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
