### PR TITLE
Add limit of 1 to missing block queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,10 @@ Ref: https://keepachangelog.com/en/1.0.0/
 
 ## Unreleased
 
+### Improvements
+
+* Add limit of 1 to missing block queries [#544](https://github.com/provenance-io/explorer-service/pull/544)
+
 ## [v5.11.0](https://github.com/provenance-io/explorer-service/releases/tag/v5.11.0) - 2024-08-27
 
 ### Improvements

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
@@ -311,7 +311,7 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
             val endTime = System.currentTimeMillis()
             val duration = endTime - startTime
 
-            // TODO: remove warning if problem is fixed after adding limit to queries
+            // TODO: remove warning if problem is fixed after adding limit to queries See: https://github.com/provenance-io/explorer-service/issues/546
             if (duration > 1000) {
                 logger().warn("Processing calculateMissedAndInsert took ${duration}ms for height: $height and valconsAddr: $valconsAddr")
             }

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
@@ -2,6 +2,7 @@ package io.provenance.explorer.domain.entities
 
 import cosmos.base.tendermint.v1beta1.Query
 import io.provenance.explorer.OBJECT_MAPPER
+import io.provenance.explorer.domain.core.logger
 import io.provenance.explorer.domain.core.sql.DateTrunc
 import io.provenance.explorer.domain.core.sql.Distinct
 import io.provenance.explorer.domain.core.sql.ExtractDOW
@@ -265,6 +266,7 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
         fun findLatestForVal(valconsAddr: String) = transaction {
             MissedBlocksRecord.find { MissedBlocksTable.valConsAddr eq valconsAddr }
                 .orderBy(Pair(MissedBlocksTable.blockHeight, SortOrder.DESC))
+                .limit(1)
                 .firstOrNull()
         }
 
@@ -272,17 +274,17 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
             MissedBlocksRecord
                 .find { (MissedBlocksTable.valConsAddr eq valconsAddr) and (MissedBlocksTable.blockHeight lessEq height) }
                 .orderBy(Pair(MissedBlocksTable.blockHeight, SortOrder.DESC))
+                .limit(1)
                 .firstOrNull()
         }
 
-        fun insert(height: Int, valconsAddr: String) = transaction {
+        fun calculateMissedAndInsert(height: Int, valconsAddr: String) = transaction {
+            val startTime = System.currentTimeMillis()
+
             val (running, total, updateFromHeight) = findLatestForVal(valconsAddr)?.let { rec ->
                 when {
-                    // If current height follows the last height, continue sequences
                     rec.blockHeight == height - 1 -> listOf(rec.runningCount, rec.totalCount, null)
                     rec.blockHeight > height ->
-                        // If current height is under the found height, find the last one directly under current
-                        // height, and see if it follows the sequence
                         when (val last = findForValFirstUnderHeight(valconsAddr, height - 1)) {
                             null -> listOf(0, 0, height)
                             else -> listOf(
@@ -291,7 +293,6 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
                                 height
                             )
                         }
-                    // Restart running sequence
                     else -> listOf(0, rec.totalCount, null)
                 }
             } ?: listOf(0, 0, null)
@@ -303,9 +304,16 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
                 it[this.totalCount] = total!! + 1
             }
 
-            // Update following height records
             if (updateFromHeight != null) {
                 updateRecords(updateFromHeight, valconsAddr, running!! + 1, total!! + 1)
+            }
+
+            val endTime = System.currentTimeMillis()
+            val duration = endTime - startTime
+
+            // TODO: remove warning if problem is fixed after adding limit to queries
+            if (duration > 1000) {
+                logger().warn("Processing calculateMissedAndInsert took ${duration}ms for height: $height and valconsAddr: $valconsAddr")
             }
         }
 

--- a/service/src/main/kotlin/io/provenance/explorer/service/ValidatorService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/ValidatorService.kt
@@ -502,7 +502,7 @@ class ValidatorService(
 
             currentVals.validatorsList.forEach { vali ->
                 if (!signatures.contains(vali.address)) {
-                    MissedBlocksRecord.insert(lastBlock.height.toInt(), vali.address)
+                    MissedBlocksRecord.calculateMissedAndInsert(lastBlock.height.toInt(), vali.address)
                 }
             }
         }


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR addresses an issue where some validators were returning up to 316k records, fetching and serializing all results into `MissedBlockRecords`, only to use the first record. This caused longer query times, unnecessary data transfer, and serialization overhead. The update optimizes performance by adding a limit to queries, reducing data processing and improving efficiency. Additionally, logging was added to warn if processing exceeds 1 second.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
