### PR TITLE
Remove the logic for calculating `running_count` and `total_count` in the `missed_blocks`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,6 +36,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 ### Improvements
 
 * Add limit of 1 to missing block queries [#544](https://github.com/provenance-io/explorer-service/pull/544)
+* Removes the logic for calculating `running_count` and `total_count` in the `missed_blocks` [#548](https://github.com/provenance-io/explorer-service/pull/548)
 
 ## [v5.11.0](https://github.com/provenance-io/explorer-service/releases/tag/v5.11.0) - 2024-08-27
 

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
@@ -264,7 +264,7 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
             MissedBlocksTable.insertIgnore {
                 it[this.blockHeight] = height
                 it[this.valConsAddr] = valconsAddr
-                // TODO: remove these column from database
+                // TODO: remove these column from database See: https://github.com/provenance-io/explorer-service/issues/549
                 it[this.runningCount] = -1
                 it[this.totalCount] = -1
             }

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Blocks.kt
@@ -2,7 +2,6 @@ package io.provenance.explorer.domain.entities
 
 import cosmos.base.tendermint.v1beta1.Query
 import io.provenance.explorer.OBJECT_MAPPER
-import io.provenance.explorer.domain.core.logger
 import io.provenance.explorer.domain.core.sql.DateTrunc
 import io.provenance.explorer.domain.core.sql.Distinct
 import io.provenance.explorer.domain.core.sql.ExtractDOW
@@ -58,9 +57,7 @@ import org.jetbrains.exposed.sql.jodatime.datetime
 import org.jetbrains.exposed.sql.leftJoin
 import org.jetbrains.exposed.sql.select
 import org.jetbrains.exposed.sql.selectAll
-import org.jetbrains.exposed.sql.statements.BatchUpdateStatement
 import org.jetbrains.exposed.sql.sum
-import org.jetbrains.exposed.sql.transactions.TransactionManager
 import org.jetbrains.exposed.sql.transactions.transaction
 import org.jetbrains.exposed.sql.update
 import org.joda.time.DateTime
@@ -263,79 +260,13 @@ class MissedBlocksRecord(id: EntityID<Int>) : IntEntity(id) {
             query.exec(arguments).map { it.getString("val_cons_address") }
         }
 
-        fun findLatestForVal(valconsAddr: String) = transaction {
-            MissedBlocksRecord.find { MissedBlocksTable.valConsAddr eq valconsAddr }
-                .orderBy(Pair(MissedBlocksTable.blockHeight, SortOrder.DESC))
-                .limit(1)
-                .firstOrNull()
-        }
-
-        fun findForValFirstUnderHeight(valconsAddr: String, height: Int) = transaction {
-            MissedBlocksRecord
-                .find { (MissedBlocksTable.valConsAddr eq valconsAddr) and (MissedBlocksTable.blockHeight lessEq height) }
-                .orderBy(Pair(MissedBlocksTable.blockHeight, SortOrder.DESC))
-                .limit(1)
-                .firstOrNull()
-        }
-
-        fun calculateMissedAndInsert(height: Int, valconsAddr: String) = transaction {
-            val startTime = System.currentTimeMillis()
-
-            val (running, total, updateFromHeight) = findLatestForVal(valconsAddr)?.let { rec ->
-                when {
-                    rec.blockHeight == height - 1 -> listOf(rec.runningCount, rec.totalCount, null)
-                    rec.blockHeight > height ->
-                        when (val last = findForValFirstUnderHeight(valconsAddr, height - 1)) {
-                            null -> listOf(0, 0, height)
-                            else -> listOf(
-                                if (last.blockHeight == height - 1) last.runningCount else 0,
-                                last.totalCount,
-                                height
-                            )
-                        }
-                    else -> listOf(0, rec.totalCount, null)
-                }
-            } ?: listOf(0, 0, null)
-
+        fun insert(height: Int, valconsAddr: String) = transaction {
             MissedBlocksTable.insertIgnore {
                 it[this.blockHeight] = height
                 it[this.valConsAddr] = valconsAddr
-                it[this.runningCount] = running!! + 1
-                it[this.totalCount] = total!! + 1
-            }
-
-            if (updateFromHeight != null) {
-                updateRecords(updateFromHeight, valconsAddr, running!! + 1, total!! + 1)
-            }
-
-            val endTime = System.currentTimeMillis()
-            val duration = endTime - startTime
-
-            // TODO: remove warning if problem is fixed after adding limit to queries See: https://github.com/provenance-io/explorer-service/issues/546
-            if (duration > 1000) {
-                logger().warn("Processing calculateMissedAndInsert took ${duration}ms for height: $height and valconsAddr: $valconsAddr")
-            }
-        }
-
-        fun updateRecords(height: Int, valconsAddr: String, currRunning: Int, currTotal: Int) = transaction {
-            val records = MissedBlocksRecord
-                .find { (MissedBlocksTable.valConsAddr eq valconsAddr) and (MissedBlocksTable.blockHeight greater height) }
-                .orderBy(Pair(MissedBlocksTable.blockHeight, SortOrder.ASC))
-
-            BatchUpdateStatement(MissedBlocksTable).apply {
-                var lastHeight = height
-                var lastRunning = currRunning
-                var lastTotal = currTotal
-                records.forEach {
-                    addBatch(it.id)
-                    val running = if (lastHeight == it.blockHeight - 1) lastRunning + 1 else 1
-                    this[MissedBlocksTable.runningCount] = running
-                    this[MissedBlocksTable.totalCount] = lastTotal + 1
-                    lastHeight = it.blockHeight
-                    lastRunning = running
-                    lastTotal += 1
-                }
-                execute(TransactionManager.current())
+                // TODO: remove these column from database
+                it[this.runningCount] = -1
+                it[this.totalCount] = -1
             }
         }
     }

--- a/service/src/main/kotlin/io/provenance/explorer/service/ValidatorService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/ValidatorService.kt
@@ -502,7 +502,7 @@ class ValidatorService(
 
             currentVals.validatorsList.forEach { vali ->
                 if (!signatures.contains(vali.address)) {
-                    MissedBlocksRecord.calculateMissedAndInsert(lastBlock.height.toInt(), vali.address)
+                    MissedBlocksRecord.insert(lastBlock.height.toInt(), vali.address)
                 }
             }
         }

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
@@ -123,6 +123,7 @@ class ScheduledTaskService(
         val index = getBlockIndex()
         val startHeight = blockService.getLatestBlockHeight()
         var indexHeight = startHeight
+        logger.info("Starting updateLatestBlockHeightJob startHeight $startHeight")
         if (startCollectingHistoricalBlocks(index) ||
             continueCollectingHistoricalBlocks(index!!.first!!, index.second!!)
         ) {

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
@@ -120,6 +120,7 @@ class ScheduledTaskService(
 
     @Scheduled(initialDelay = 0L, fixedDelay = 5000L)
     fun updateLatestBlockHeightJob() {
+        var count = 0
         val index = getBlockIndex()
         val startHeight = blockService.getLatestBlockHeight()
         var indexHeight = startHeight
@@ -139,6 +140,7 @@ class ScheduledTaskService(
                     blockAndTxProcessor.saveBlockEtc(it)
                     indexHeight = it.block.height() - 1
                 }
+                count++
                 blockService.updateBlockMinHeightIndex(indexHeight + 1)
             }
             blockService.updateBlockMaxHeightIndex(startHeight)
@@ -147,6 +149,7 @@ class ScheduledTaskService(
                 blockService.getBlockAtHeightFromChain(indexHeight)?.let {
                     blockAndTxProcessor.saveBlockEtc(it)
                     indexHeight = it.block.height() - 1
+                    count++
                 }
             }
             blockService.updateBlockMaxHeightIndex(startHeight)
@@ -157,6 +160,7 @@ class ScheduledTaskService(
         if (!cacheService.getCacheValue(CacheKeys.SPOTLIGHT_PROCESSING.key)!!.cacheValue.toBoolean()) {
             cacheService.updateCacheValue(CacheKeys.SPOTLIGHT_PROCESSING.key, true.toString())
         }
+        logger.info("Finished updateLatestBlockHeightJob added: $count")
     }
 
     fun getBlockIndex() = blockService.getBlockIndexFromCache()?.let {

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
@@ -152,7 +152,7 @@ class ScheduledTaskService(
         }
 
         BlockTxCountsCacheRecord.updateTxCounts()
-         BlockProposerRecord.calcLatency()
+        BlockProposerRecord.calcLatency()
         if (!cacheService.getCacheValue(CacheKeys.SPOTLIGHT_PROCESSING.key)!!.cacheValue.toBoolean()) {
             cacheService.updateCacheValue(CacheKeys.SPOTLIGHT_PROCESSING.key, true.toString())
         }

--- a/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/async/ScheduledTaskService.kt
@@ -143,6 +143,7 @@ class ScheduledTaskService(
                 count++
                 blockService.updateBlockMinHeightIndex(indexHeight + 1)
             }
+            logger.info("Finished updateLatestBlockHeightJob historical added: $count")
             blockService.updateBlockMaxHeightIndex(startHeight)
         } else {
             while (indexHeight > index.first!!) {
@@ -152,15 +153,16 @@ class ScheduledTaskService(
                     count++
                 }
             }
+            logger.info("Finished updateLatestBlockHeightJob added: $count")
             blockService.updateBlockMaxHeightIndex(startHeight)
         }
 
         BlockTxCountsCacheRecord.updateTxCounts()
-        BlockProposerRecord.calcLatency()
+        // BlockProposerRecord.calcLatency()
         if (!cacheService.getCacheValue(CacheKeys.SPOTLIGHT_PROCESSING.key)!!.cacheValue.toBoolean()) {
             cacheService.updateCacheValue(CacheKeys.SPOTLIGHT_PROCESSING.key, true.toString())
         }
-        logger.info("Finished updateLatestBlockHeightJob added: $count")
+        logger.info("Finished updateLatestBlockHeightJob")
     }
 
     fun getBlockIndex() = blockService.getBlockIndexFromCache()?.let {


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->
This PR removes the logic for calculating running_count and total_count in the missed_blocks table. We no longer need to store these values in the database since they can be easily derived with a simple query when necessary.

Previously, the calculation of these values could take several minutes when a validator missed a block, especially with large datasets. Now, only the consensus_address and block_missed are stored, which eliminates that overhead. The counts were not used in any endpoints or elsewhere in the code, so this cleanup improves performance without affecting functionality.

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
