### PR TITLE
Modify workflow to not append the `run-number` to `latest` docker tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,7 +32,6 @@ jobs:
           echo ::set-output name=branch::${VERSION}
           if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
             VERSION=latest
-          fi
           else 
             VERSION="${VERSION}-${{github.run_number}}"
           fi 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,51 +15,53 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up JDK 11
-      uses: actions/setup-java@v1
-      with:
-        java-version: 11
-    - name: Prepare
-      id: prep
-      run: |
-        DOCKER_IMAGE=provenanceio/explorer-service
-        VERSION=noop
-        if [[ $GITHUB_REF == refs/tags/* ]]; then
-          VERSION=${GITHUB_REF#refs/tags/}
-        elif [[ $GITHUB_REF == refs/heads/* ]]; then
-          VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-          echo ::set-output name=branch::${VERSION}
-          if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-            VERSION=latest
+      - uses: actions/checkout@v2
+      - name: Set up JDK 11
+        uses: actions/setup-java@v1
+        with:
+          java-version: 11
+      - name: Prepare
+        id: prep
+        run: |
+          DOCKER_IMAGE=provenanceio/explorer-service
+          VERSION=noop
+          if [[ $GITHUB_REF == refs/tags/* ]]; then
+            VERSION=${GITHUB_REF#refs/tags/}
+          elif [[ $GITHUB_REF == refs/heads/* ]]; then
+            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+            echo ::set-output name=branch::${VERSION}
+            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+              VERSION=latest
+            else
+              VERSION="${VERSION}-${{github.run_number}}"
+            fi
           fi
-        fi
-        TAGS="${DOCKER_IMAGE}:${VERSION}-${{github.run_number}}"
-        if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-          TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
-        fi
-        echo ::set-output name=version::${VERSION}
-        echo ::set-output name=tags::${TAGS}
-        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v1
-    - name: Login to DockerHub
-      uses: docker/login-action@v1
-      with:
-        username: ${{ secrets.DOCKERHUB_USERNAME }}
-        password: ${{ secrets.DOCKERHUB_TOKEN }}
-    - name: Build and push service docker
-      uses: docker/build-push-action@v2
-      with:
-        file: docker/Dockerfile-service
-        context: .
-        push: true
-        tags: ${{ steps.prep.outputs.tags }}
-    - name: Build and push database docker
-      uses: docker/build-push-action@v2
-      if: ${{ steps.prep.outputs.branch == github.event.repository.default_branch }}
-      with:
-        file: docker/Dockerfile-database
-        context: .
-        push: true
-        tags: provenanceio/explorer-database:latest
+          TAGS="${DOCKER_IMAGE}:${VERSION}"
+          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+          fi
+          echo ::set-output name=version::${VERSION}
+          echo ::set-output name=tags::${TAGS}
+          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - name: Build and push service docker
+        uses: docker/build-push-action@v2
+        with:
+          file: docker/Dockerfile-service
+          context: .
+          push: true
+          tags: ${{ steps.prep.outputs.tags }}
+      - name: Build and push database docker
+        uses: docker/build-push-action@v2
+        if: ${{ steps.prep.outputs.branch == github.event.repository.default_branch }}
+        with:
+          file: docker/Dockerfile-database
+          context: .
+          push: true
+          tags: provenanceio/explorer-database:latest

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -15,53 +15,54 @@ jobs:
   docker:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - name: Set up JDK 11
-        uses: actions/setup-java@v1
-        with:
-          java-version: 11
-      - name: Prepare
-        id: prep
-        run: |
-          DOCKER_IMAGE=provenanceio/explorer-service
-          VERSION=noop
-          if [[ $GITHUB_REF == refs/tags/* ]]; then
-            VERSION=${GITHUB_REF#refs/tags/}
-          elif [[ $GITHUB_REF == refs/heads/* ]]; then
-            VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
-            echo ::set-output name=branch::${VERSION}
-            if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
-              VERSION=latest
-            else
-              VERSION="${VERSION}-${{github.run_number}}"
-            fi
+    - uses: actions/checkout@v2
+    - name: Set up JDK 11
+      uses: actions/setup-java@v1
+      with:
+        java-version: 11
+    - name: Prepare
+      id: prep
+      run: |
+        DOCKER_IMAGE=provenanceio/explorer-service
+        VERSION=noop
+        if [[ $GITHUB_REF == refs/tags/* ]]; then
+          VERSION=${GITHUB_REF#refs/tags/}
+        elif [[ $GITHUB_REF == refs/heads/* ]]; then
+          VERSION=$(echo ${GITHUB_REF#refs/heads/} | sed -r 's#/+#-#g')
+          echo ::set-output name=branch::${VERSION}
+          if [ "${{ github.event.repository.default_branch }}" = "$VERSION" ]; then
+            VERSION=latest
           fi
-          TAGS="${DOCKER_IMAGE}:${VERSION}"
-          if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
-            TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
-          fi
-          echo ::set-output name=version::${VERSION}
-          echo ::set-output name=tags::${TAGS}
-          echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
-      - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v1
-      - name: Login to DockerHub
-        uses: docker/login-action@v1
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      - name: Build and push service docker
-        uses: docker/build-push-action@v2
-        with:
-          file: docker/Dockerfile-service
-          context: .
-          push: true
-          tags: ${{ steps.prep.outputs.tags }}
-      - name: Build and push database docker
-        uses: docker/build-push-action@v2
-        if: ${{ steps.prep.outputs.branch == github.event.repository.default_branch }}
-        with:
-          file: docker/Dockerfile-database
-          context: .
-          push: true
-          tags: provenanceio/explorer-database:latest
+          else 
+            VERSION="${VERSION}-${{github.run_number}}"
+          fi 
+        fi
+        TAGS="${DOCKER_IMAGE}:${VERSION}"
+        if [[ $VERSION =~ ^v[0-9]{1,3}\.[0-9]{1,3}\.[0-9]{1,3}$ ]]; then
+          TAGS="$TAGS,${DOCKER_IMAGE}:${VERSION}"
+        fi
+        echo ::set-output name=version::${VERSION}
+        echo ::set-output name=tags::${TAGS}
+        echo ::set-output name=created::$(date -u +'%Y-%m-%dT%H:%M:%SZ')
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v1
+    - name: Login to DockerHub
+      uses: docker/login-action@v1
+      with:
+        username: ${{ secrets.DOCKERHUB_USERNAME }}
+        password: ${{ secrets.DOCKERHUB_TOKEN }}
+    - name: Build and push service docker
+      uses: docker/build-push-action@v2
+      with:
+        file: docker/Dockerfile-service
+        context: .
+        push: true
+        tags: ${{ steps.prep.outputs.tags }}
+    - name: Build and push database docker
+      uses: docker/build-push-action@v2
+      if: ${{ steps.prep.outputs.branch == github.event.repository.default_branch }}
+      with:
+        file: docker/Dockerfile-database
+        context: .
+        push: true
+        tags: provenanceio/explorer-database:latest

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Add limit of 1 to missing block queries [#544](https://github.com/provenance-io/explorer-service/pull/544)
 * Removes the logic for calculating `running_count` and `total_count` in the `missed_blocks` [#548](https://github.com/provenance-io/explorer-service/pull/548)
 * Remove update block latency procedure call [#550](https://github.com/provenance-io/explorer-service/pull/550)
+* Docker images at tag `latest` for main branch merges [#551](https://github.com/provenance-io/explorer-service/pull/551)
 
 ## [v5.11.0](https://github.com/provenance-io/explorer-service/releases/tag/v5.11.0) - 2024-08-27
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR updates the Docker workflow to ensure that the `latest` tag in the Docker repository correctly represents the code from the `main` branch, removing the previous behavior of appending a run number to the tag (e.g., `latest-<run-number>`). The outdated `latest` tag was causing issues with ArgoCD, which was attempting to pull the most recent `latest` image but instead retrieved the outdated tag, leading to deployment problems. 

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
