### PR TITLE
Set asset pricing data column to null on updates from flow grpc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -46,6 +46,7 @@ Ref: https://keepachangelog.com/en/1.0.0/
 * Docker images at tag `latest` for main branch merges [#551](https://github.com/provenance-io/explorer-service/pull/551)
 * Refactor account processing implementation to be more efficient [#552](https://github.com/provenance-io/explorer-service/issues/552)
 * Update keep alive times for flow api grpc calls [#558](https://github.com/provenance-io/explorer-service/pull/558)
+* Updates to asset pricing table will set data column to null [#562](https://github.com/provenance-io/explorer-service/pull/562)
 
 ## [v5.11.0](https://github.com/provenance-io/explorer-service/releases/tag/v5.11.0) - 2024-08-27
 

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Markers.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Markers.kt
@@ -245,7 +245,6 @@ class AssetPricingRecord(id: EntityID<Int>) : IntEntity(id) {
                 it[this.pricing] = pricingAmount
                 it[this.pricingDenom] = pricingDenom
                 it[this.lastUpdated] = timestamp
-                it[this.data] = null
             }
         }
 

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Markers.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Markers.kt
@@ -219,7 +219,7 @@ object AssetPricingTable : IdTable<Int>(name = "asset_pricing") {
     val pricing = decimal("pricing", 100, 50)
     val pricingDenom = varchar("pricing_denom", 256)
     val lastUpdated = datetime("last_updated")
-    val data = jsonb<AssetPricingTable, AssetPricing>("data", OBJECT_MAPPER)
+    val data = jsonb<AssetPricingTable, AssetPricing>("data", OBJECT_MAPPER).nullable()
 }
 
 class AssetPricingRecord(id: EntityID<Int>) : IntEntity(id) {
@@ -237,6 +237,7 @@ class AssetPricingRecord(id: EntityID<Int>) : IntEntity(id) {
             findUnique(markerDenom, pricingDenom)?.apply {
                 this.pricing = pricingAmount
                 this.lastUpdated = timestamp
+                this.data = null
             } ?: AssetPricingTable.insert {
                 it[this.markerId] = markerId
                 it[this.markerAddress] = markerAddress ?: ""
@@ -244,6 +245,7 @@ class AssetPricingRecord(id: EntityID<Int>) : IntEntity(id) {
                 it[this.pricing] = pricingAmount
                 it[this.pricingDenom] = pricingDenom
                 it[this.lastUpdated] = timestamp
+                it[this.data] = null
             }
         }
 


### PR DESCRIPTION
<!-- < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < < ☺
v                               ✰  Thanks for creating a PR! ✰
v    Before smashing the submit button please review the checkboxes.
v    If a checkbox is n/a - please still include it but + a little note why
☺ > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > > >  -->

## Description

<!-- Add a description of the changes that this PR introduces and the files that
are the most critical to review.
-->

This PR modifies the asset pricing update logic by ensuring the `data` column is set to `null` on update or insert. Previously, the `data` column contained the json response from the figure pricing service, which is no longer necessary since data now comes from the Flow API. By nullifying the `data` column, we remove this outdate content. 

This column will be removed completely in the future: https://github.com/provenance-io/explorer-service/issues/563

closes: #XXXX

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
