### PR TITLE
- update to java 21

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -18,7 +18,7 @@ jobs:
         uses: actions/setup-java@v3
         with:
           distribution: 'zulu'
-          java-version: 11
+          java-version: 21
           server-id: github
 
       - name: GPG Setup


### PR DESCRIPTION
Missed updating to jdk 21 for the publish process of the main branch. 