### PR TITLE
Fix Msg Event Attr Table Integer Overflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,13 @@ Types of changes (Stanzas):
 "Data" for any data changes.
 Ref: https://keepachangelog.com/en/1.0.0/
 -->
+## [v7.0.5](https://github.com/provenance-io/explorer-service/releases/tag/v7.0.5) - 2025-03-20
+
+### Bug Fixes
+
+Version 7.0.5 of the Explorer Service fixes a Postgresql sequence integer overflow
+issue in the tx_msg_event_attr table. The number of rows exceeded 2.17B, the max
+integer value. Table primary key and sequence were updated to BIGINT.
 
 ## [v7.0.4](https://github.com/provenance-io/explorer-service/releases/tag/v7.0.4) - 2025-03-13
 

--- a/RELEASE_CHANGELOG.md
+++ b/RELEASE_CHANGELOG.md
@@ -1,32 +1,7 @@
-## [v7.0.0](https://github.com/provenance-io/explorer-service/releases/tag/v7.0.0) - 2025-02-12
-
-## Upgrades
-Version 7 of explorer consists of a mass of dependency upgrades that led to a multitude of other cleanups.
-
-**Highlights**
-- Java 21
-- Kotlin 1.9.25
-- Gradle 8
-- SpringBoot 3.2.4
-- Jakarta EE
-- SpringDoc w/ Swagger 3
-- Java Time
-
-## Improvements
-* Removed materialized view that is unnecessary and causes misdirection when debugging performance issues
-* Add a caching interface for block and transaction queries that tend to be used often
-* Optimize governance transaction fetching to return results in a timely fashion
-* Updated build actions to reduce noise
-* Add ktlint to the top level build files
-  * Add linter pre-commit hook (Thanks to the Figure Markets team)
-* Revamp build files to clean up dependency handling
-  * Use libs.versions.toml for dependency declarations
-* update to json logging output for better error handling
-
+## [v7.0.5](https://github.com/provenance-io/explorer-service/releases/tag/v7.0.5) - 2025-03-20
 
 ### Bug Fixes
-* Resolve explorer service restarts due to database connection starvation caused by long running governance transaction queries
-* Resolve caching issues that caused the internal transaction fetch cache to not be used
-* In certain cases spendable balance wasn't able to be fetched
-  * query performance improved
-* Event processing updates to catch events that were missed since the last Provenance upgrade
+
+Version 7.0.5 of the Explorer Service fixes a Postgresql sequence integer overflow
+issue in the tx_msg_event_attr table. The number of rows exceeded 2.17B, the max
+integer value. Table primary key and sequence were updated to BIGINT.

--- a/database/src/main/resources/db/migration/V1_100__add_block_show_error.sql
+++ b/database/src/main/resources/db/migration/V1_100__add_block_show_error.sql
@@ -1,0 +1,46 @@
+CREATE OR REPLACE PROCEDURE add_block(bd block_update)
+    LANGUAGE plpgsql
+AS
+$$
+DECLARE
+    tx_height INT; --block height
+    timez     TIMESTAMP; -- block timestamp
+    tu        tx_update;
+BEGIN
+    SELECT (bd).blocks.height INTO tx_height;
+    SELECT (bd).blocks.block_timestamp INTO timez;
+    -- insert block
+    INSERT INTO block_cache(height, tx_count, block_timestamp, block, last_hit, hit_count)
+    VALUES (tx_height,
+            (bd).blocks.tx_count,
+            timez,
+            (bd).blocks.block,
+            (bd).blocks.last_hit,
+            (bd).blocks.hit_count)
+    ON CONFLICT (height) DO NOTHING;
+    -- insert block tx count
+    INSERT INTO block_tx_count_cache(block_height, block_timestamp, tx_count)
+    VALUES (tx_height, timez, (bd).blocks.tx_count)
+    ON CONFLICT (block_height) DO NOTHING;
+    -- insert block proposer fee
+    INSERT INTO block_proposer(block_height, block_timestamp, proposer_operator_address, block_latency)
+    VALUES (tx_height,
+            timez,
+            (bd).proposer.proposer_operator_address,
+            (bd).proposer.block_latency)
+    ON CONFLICT (block_height) DO NOTHING;
+    -- insert validator cache
+    INSERT INTO validators_cache(height, validators, last_hit, hit_count)
+    VALUES (tx_height, (bd).validatorCache.validators, (bd).validatorCache.last_hit, (bd).validatorCache.hit_count)
+    ON CONFLICT (height) DO NOTHING;
+    -- for each tx
+    FOREACH tu IN ARRAY (bd).txs
+        LOOP
+            CALL add_tx(tu, tx_height, timez);
+        END LOOP;
+    RAISE INFO 'UPDATED block';
+EXCEPTION
+    WHEN others THEN
+        RAISE EXCEPTION 'Error saving block %. Error Code: %, Message: %.', (bd).blocks.height, SQLSTATE, SQLERRM;
+END;
+$$;

--- a/database/src/main/resources/db/migration/V1_101__update_int_PK_columns.sql
+++ b/database/src/main/resources/db/migration/V1_101__update_int_PK_columns.sql
@@ -1,0 +1,5 @@
+ALTER TABLE tx_msg_event ALTER COLUMN id SET DATA TYPE BIGINT;
+ALTER SEQUENCE tx_msg_event_id_seq AS BIGINT;
+
+ALTER TABLE tx_msg_event_attr ALTER COLUMN id SET DATA TYPE BIGINT;
+ALTER SEQUENCE tx_msg_event_attr_id_seq AS BIGINT;

--- a/database/src/main/resources/db/migration/V1_101__update_int_PK_columns.sql
+++ b/database/src/main/resources/db/migration/V1_101__update_int_PK_columns.sql
@@ -1,5 +1,23 @@
-ALTER TABLE tx_msg_event ALTER COLUMN id SET DATA TYPE BIGINT;
-ALTER SEQUENCE tx_msg_event_id_seq AS BIGINT;
+DO
+$$
+    DECLARE
+        v_column_type TEXT;
+    BEGIN
+        -- Check if the column exists and get its current data type
+        SELECT data_type
+        INTO v_column_type
+        FROM information_schema.columns
+        WHERE table_name = 'tx_msg_event_attr'
+          AND column_name = 'id';
 
-ALTER TABLE tx_msg_event_attr ALTER COLUMN id SET DATA TYPE BIGINT;
-ALTER SEQUENCE tx_msg_event_attr_id_seq AS BIGINT;
+        -- If the column is of type INTEGER, change it to BIGINT
+        IF v_column_type = 'integer' THEN
+            ALTER TABLE tx_msg_event_attr ALTER COLUMN id SET DATA TYPE BIGINT;
+            ALTER SEQUENCE tx_msg_event_attr_id_seq AS BIGINT;
+            RAISE NOTICE 'Column id in table tx_msg_event_attr changed to BIGINT.';
+        ELSE
+            RAISE NOTICE 'Column tx_msg_event_attr is already BIGINT or does not exist.';
+        END IF;
+    END
+$$;
+

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
@@ -563,7 +563,7 @@ class TxMessageRecord(id: EntityID<Int>) : IntEntity(id) {
     var txTimestamp by TxMessageTable.txTimestamp
 }
 
-object TxEventsTable : LongIdTable(name = "tx_msg_event") {
+object TxEventsTable : IntIdTable(name = "tx_msg_event") {
     val blockHeight = integer("block_height")
     val txHash = varchar("tx_hash", 64)
     val txHashId = reference("tx_hash_id", TxCacheTable)
@@ -572,8 +572,8 @@ object TxEventsTable : LongIdTable(name = "tx_msg_event") {
     val eventType = varchar("event_type", 256)
 }
 
-class TxEventRecord(id: EntityID<Long>) : LongEntity(id) {
-    companion object : LongEntityClass<TxEventRecord>(TxEventsTable) {
+class TxEventRecord(id: EntityID<Int>) : IntEntity(id) {
+    companion object : IntEntityClass<TxEventRecord>(TxEventsTable) {
 
         fun buildInsert(blockHeight: Int, txHash: String, type: String, msgTypeId: Int) =
             listOf(0, blockHeight, 0, txHash, 0, type, msgTypeId).toProcedureObject()
@@ -588,7 +588,7 @@ class TxEventRecord(id: EntityID<Long>) : LongEntity(id) {
 }
 
 object TxEventAttrTable : LongIdTable(name = "tx_msg_event_attr") {
-    val txMsgEventId = long("tx_msg_event_id")
+    val txMsgEventId = integer("tx_msg_event_id")
     val attrKey = varchar("attr_key", 256)
     val attrValue = text("attr_value")
     val attrIdx = integer("attr_idx")

--- a/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/domain/entities/Transactions.kt
@@ -44,8 +44,11 @@ import io.provenance.explorer.model.base.stringfy
 import io.provenance.explorer.service.AssetService
 import org.jetbrains.exposed.dao.IntEntity
 import org.jetbrains.exposed.dao.IntEntityClass
+import org.jetbrains.exposed.dao.LongEntity
+import org.jetbrains.exposed.dao.LongEntityClass
 import org.jetbrains.exposed.dao.id.EntityID
 import org.jetbrains.exposed.dao.id.IntIdTable
+import org.jetbrains.exposed.dao.id.LongIdTable
 import org.jetbrains.exposed.sql.ColumnSet
 import org.jetbrains.exposed.sql.ColumnType
 import org.jetbrains.exposed.sql.Expression
@@ -560,7 +563,7 @@ class TxMessageRecord(id: EntityID<Int>) : IntEntity(id) {
     var txTimestamp by TxMessageTable.txTimestamp
 }
 
-object TxEventsTable : IntIdTable(name = "tx_msg_event") {
+object TxEventsTable : LongIdTable(name = "tx_msg_event") {
     val blockHeight = integer("block_height")
     val txHash = varchar("tx_hash", 64)
     val txHashId = reference("tx_hash_id", TxCacheTable)
@@ -569,8 +572,8 @@ object TxEventsTable : IntIdTable(name = "tx_msg_event") {
     val eventType = varchar("event_type", 256)
 }
 
-class TxEventRecord(id: EntityID<Int>) : IntEntity(id) {
-    companion object : IntEntityClass<TxEventRecord>(TxEventsTable) {
+class TxEventRecord(id: EntityID<Long>) : LongEntity(id) {
+    companion object : LongEntityClass<TxEventRecord>(TxEventsTable) {
 
         fun buildInsert(blockHeight: Int, txHash: String, type: String, msgTypeId: Int) =
             listOf(0, blockHeight, 0, txHash, 0, type, msgTypeId).toProcedureObject()
@@ -584,16 +587,16 @@ class TxEventRecord(id: EntityID<Int>) : IntEntity(id) {
     var eventType by TxEventsTable.eventType
 }
 
-object TxEventAttrTable : IntIdTable(name = "tx_msg_event_attr") {
-    val txMsgEventId = integer("tx_msg_event_id")
+object TxEventAttrTable : LongIdTable(name = "tx_msg_event_attr") {
+    val txMsgEventId = long("tx_msg_event_id")
     val attrKey = varchar("attr_key", 256)
     val attrValue = text("attr_value")
     val attrIdx = integer("attr_idx")
     val attrHash = text("attr_hash")
 }
 
-class TxEventAttrRecord(id: EntityID<Int>) : IntEntity(id) {
-    companion object : IntEntityClass<TxEventAttrRecord>(TxEventAttrTable) {
+class TxEventAttrRecord(id: EntityID<Long>) : LongEntity(id) {
+    companion object : LongEntityClass<TxEventAttrRecord>(TxEventAttrTable) {
 
         fun buildInsert(idx: Int, key: String, value: String) =
             listOf(0, 0, key, value, idx, listOf(idx, key, value).joinToString("").toDbHash()).toProcedureObject()


### PR DESCRIPTION
## Description

The tx_msg_event_attr table uses an INT primary key column with a sequence. The number of rows exceeded the max integer value (2.17B) and the sequence nextval is puking. This converts the INT to BIGINT in the PK and seq.