### PR TITLE
Fix Backfill Datetime to End-of-Day

### DIFF
--- a/service/src/main/kotlin/io/provenance/explorer/service/PulseMetricService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/PulseMetricService.kt
@@ -1512,7 +1512,14 @@ class PulseMetricService(
             try {
                 val days = fromDate.until(toDate, ChronoUnit.DAYS)
                 for (i in 0..days) {
-                    val d = fromDate.plusDays(i).atStartOfDay()
+                    /*
+                     Pulse works on the principal that the metric for a given
+                     is the aggregation of all events for that date. So we need to
+                     set the backfill date the end of the day to ensure that we
+                     capture all events for that date.
+                     */
+                    //
+                    val d = endOfDay(fromDate.plusDays(i).atStartOfDay())
                     for (type in types) {
                         try {
                             logger.info("Backfilling $type for $d")

--- a/service/src/main/kotlin/io/provenance/explorer/service/PulseMetricService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/PulseMetricService.kt
@@ -1518,7 +1518,6 @@ class PulseMetricService(
                      set the backfill date the end of the day to ensure that we
                      capture all events for that date.
                      */
-                    //
                     val d = endOfDay(fromDate.plusDays(i).atStartOfDay())
                     for (type in types) {
                         try {


### PR DESCRIPTION
## Description

Backfill date needs to use the end-of-day time instead of start-of-day otherwise certain metric events (tx count) are missed for the day.

closes: #607 

---

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [x] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [x] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [x] Wrote unit and integration
- [x] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [x] Re-reviewed `Files changed` in the Github PR explorer
- [x] Review `Codecov Report` in the comment section below once CI passes
