### PR TITLE
pulse 404

### DIFF
--- a/service/src/main/kotlin/io/provenance/explorer/service/PulseMetricService.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/service/PulseMetricService.kt
@@ -606,6 +606,11 @@ class PulseMetricService(
             atDateTime = atDateTime
         )
     } else {
+        // populate current days metric if we haven't at this point
+        if (fromPulseMetricCache(nowUTC().toLocalDate(), type) == null) {
+            transactionVolume(range = range)
+        }
+
         val spans = rangeOverRangeSpans(
             range = range,
             type = type


### PR DESCRIPTION
Pule metric PULSE_TRANSACTION_VOLUME_METRIC will return a 404 if called prior to the first scheduled run of the day. This will makes sure the cache has been populated for the current day before trying the range spans logic.

Before we can merge this PR, please make sure that all the following items have been
checked off. If any of the checklist items are not applicable, please leave them but
write a little note why.

- [ ] Targeted PR against correct branch (see [CONTRIBUTING.md](https://github.com/provenance-io/explorer/blob/main/CONTRIBUTING.md#pr-targeting))
- [ ] Linked to Github issue with discussion and accepted design OR link to spec that describes this work.
- [ ] Wrote unit and integration
- [ ] Added a relevant changelog entry to the `Unreleased` section in `CHANGELOG.md`
- [ ] Re-reviewed `Files changed` in the Github PR explorer
- [ ] Review `Codecov Report` in the comment section below once CI passes
