### PR TITLE
Change default vesting period back to DAY

### DIFF
--- a/service/src/main/kotlin/io/provenance/explorer/web/v3/AccountControllerV3.kt
+++ b/service/src/main/kotlin/io/provenance/explorer/web/v3/AccountControllerV3.kt
@@ -71,8 +71,8 @@ class AccountControllerV3(private val accountService: AccountService, private va
         @Parameter(description = "The address of the account, starting with the standard account prefix")
         @PathVariable
         address: String,
-        @Parameter(description = "The period selection for a ContinuousVestingAccount", schema = Schema(defaultValue = "MONTH"), required = false)
-        @RequestParam(defaultValue = "MONTH")
+        @Parameter(description = "The period selection for a ContinuousVestingAccount", schema = Schema(defaultValue = "DAY"), required = false)
+        @RequestParam(defaultValue = "DAY")
         continuousPeriod: PeriodInSeconds
     ) = accountService.getVestingSchedule(address, continuousPeriod)
 


### PR DESCRIPTION
We updated the default vesting period to MONTH due to performance issues. With that fixed, we can revert this back to DAY.
